### PR TITLE
googletest recipe: version bump, add modulefile, fix install

### DIFF
--- a/googletest.sh
+++ b/googletest.sh
@@ -1,15 +1,29 @@
 package: googletest
-version: "1.7.0"
+version: "1.8.0"
 source: https://github.com/google/googletest
-tag: release-1.7.0
+tag: release-1.8.0
 build_requires:
  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/sh
 cmake $SOURCEDIR                           \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+cmake --build . --target install -- ${JOBS+-j $JOBS}
 
-make ${JOBS+-j $JOBS}
-mkdir -p $INSTALLROOT/lib
-cp *.a $INSTALLROOT/lib
-rsync -av $SOURCEDIR/include/ $INSTALLROOT/include/
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+setenv GTEST_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+EoF


### PR DESCRIPTION
  * bump version to 1.8.0
  * add modulefile (exports GTEST_ROOT needed by FindGTest.cmake)
  * install via install target